### PR TITLE
runtime: remove accept header from exclude list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ httpsignature-proxy
 # vendor/
 
 dist/
+.idea

--- a/service/runtime/handler.go
+++ b/service/runtime/handler.go
@@ -47,7 +47,7 @@ var (
 	upvestClientID = "upvest-client-id"
 	tokenEndpoint  = "/auth/token"
 
-	excludedHeaders = []string{hostHeader, acceptEncodingHeader, connectionHeader, acceptHeader, userAgentHeader}
+	excludedHeaders = []string{hostHeader, acceptEncodingHeader, connectionHeader, userAgentHeader}
 )
 
 type Handler struct {


### PR DESCRIPTION
# Remove Accept header from exclude list in request handler

## What

Accept header is now copied from original request when copying handling it.

## Why

Having Accept header in exclude list causes Accept header not to be passed to destination. Thus it is impossible to fetch e.g. PDF report.
