### PR TITLE
runtime: forward also query parameters of incoming request

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"time"
 
@@ -61,8 +62,8 @@ func (c *BaseConfig) Validate() error {
 	if _, err := os.Stat(c.PrivateKeyFileName); errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("private key file not exists: %s", c.PrivateKeyFileName)
 	}
-	if c.BaseUrl == "" {
-		return errors.New("base url is empty")
+	if _, err := url.Parse(c.BaseUrl); err != nil || c.BaseUrl == "" {
+		return errors.New("base url is empty or invalid")
 	}
 	return nil
 }

--- a/service/runtime/handler.go
+++ b/service/runtime/handler.go
@@ -199,7 +199,6 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, inReq *http.Request) {
 		return
 	}
 
-	// toUrl := fmt.Sprintf("%s%s", signerCfg.KeyConfig.BaseUrl, inReq.URL.Path)
 	toUrl, err := url.Parse(signerCfg.KeyConfig.BaseUrl)
 	if err != nil {
 		h.log.Log("Wrong base URL")

--- a/service/runtime/runtime_test.go
+++ b/service/runtime/runtime_test.go
@@ -106,13 +106,14 @@ func (s *TestRuntimeSuite) setupRuntime(cfg *config.Config) {
 }
 
 func (s *TestRuntimeSuite) Test_RuntimeRun() {
-	url := fmt.Sprintf("http://localhost:%d/%s", runtimePort, "endpoint")
+	url := fmt.Sprintf("http://localhost:%d/%s", runtimePort, "endpoint?param=val")
 	pl := []byte("This is the body")
 	body := bytes.NewBuffer(pl)
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, body)
 	require.NoError(s.T(), err)
 	req.Header.Set("upvest-client-id", s.clientID.String())
+	require.True(s.T(), req.URL.Query().Has("param"))
 
 	client := &http.Client{}
 	resp, err := client.Do(req)


### PR DESCRIPTION
# runtime: forward also query parameters of incoming request

## What

Forward query parameters of incoming request to sign

## Why

Many important controls are passed as query parameters (i.e. pagination params), without this fix, it is impossible to use them with signature proxy
