### PR TITLE
Make the server accessable from external endpoints

### DIFF
--- a/service/runtime/runtime.go
+++ b/service/runtime/runtime.go
@@ -53,7 +53,7 @@ func (r *Runtime) Run() {
 func (r *Runtime) installServer() {
 	handler := newHandler(r.cfg, r.signerConfigs, r.logger)
 	r.server = &http.Server{
-		Addr:    fmt.Sprintf("localhost:%d", r.cfg.Port),
+		Addr:    fmt.Sprintf(":%d", r.cfg.Port),
 		Handler: handler}
 	log.Fatal(r.server.ListenAndServe())
 }


### PR DESCRIPTION
# PR Title
Make the server accessible from external endpoints
## What
Change server configuration to get access to the Proxy from external endpoint.

## Why
We are going to use this proxy to reach the Upvest API.
In our project, we will use multiple components to connect to the Upvest API. Instead of modifying each component separately, it would be more convenient to set up a single proxy.
We have already containerized the proxy using Docker, but it is currently only accessible within the container due to its localhost limitation. Therefore, our goal is to extend the proxy's configuration to enable external access.

## Known limitations
If everything is fine, probably we also need to update README.

## Related tickets
