### PR TITLE
patch(README): fix OSX typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Generated key should be in PEM format. You can see an example in
 
 ## Generate ed25519 key pair
 
-OSx does not support the native generation of ed25519 private/public key pair.
+OSX does not support the native generation of ed25519 private/public key pair.
 You can use this way of generation **only on OS Unix based systems**.
 
 Generate private ed25519 key:

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -58,7 +58,6 @@ var startCmd = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Setup the CLI arguments for start command
-
 		startProxy()
 	},
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 	"runtime"
+	"strings"
 
 	"github.com/gookit/color"
 	"github.com/spf13/cobra"
@@ -42,7 +43,12 @@ var versionCmd = &cobra.Command{
 
 func printVersion() {
 	cyan := color.FgCyan.Render
-	fmt.Printf("httpsignature-proxy %s\nbuilt with %s from commit %s at %s by %s\n", cyan(version), cyan(runtime.Version()), cyan(commit), cyan(date), cyan(builtBy))
+	info := []string{
+		fmt.Sprintf("httpsignature-proxy %s", cyan(version)),
+		fmt.Sprintf("built with %s from commit %s at %s by %s", cyan(runtime.Version()), cyan(commit), cyan(date), cyan(builtBy)),
+	}
+	output := strings.Join(info, "\n")
+	fmt.Println(output)
 }
 
 func init() {


### PR DESCRIPTION
fixes a small typo in the README