### PR TITLE
ENGEN-4049 Pin goreleaser/goreleaser-action to a commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           go-version: '1.23.5'
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser


### PR DESCRIPTION
## Summary
- Pins `goreleaser/goreleaser-action` to the org-approved commit SHA (`9c156ee8...` / v6.3.0) instead of the moving `@v5` tag, matching the fix already applied to upbox.
- No behavior change. Same goreleaser version/args run, just via a pinned commit of the action itself.